### PR TITLE
Update for magicgui 0.2 API change

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
 dask-image
-magicgui
-napari>=0.3.3
+magicgui>=0.2.5
+napari>=0.4.3
 numpy
 pandas
 scikit-image

--- a/examples/video_annotation.py
+++ b/examples/video_annotation.py
@@ -1,6 +1,4 @@
-from skimage import data
-
 from pointannotator import point_annotator
 
-im_path = '/Users/yamauc0000/Documents/DeepLabCut/examples/openfield-Pranav-2018-10-30/labeled-data/m4s1/*.png'
+im_path = '<path to>/openfield-Pranav-2018-10-30/labeled-data/m4s1/*.png'
 point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'])

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -3,7 +3,7 @@ from typing import List
 from dask_image.imread import imread
 import napari
 import numpy as np
-from magicgui.widgets import ComboBox, Container, Label
+from magicgui.widgets import ComboBox, Container
 
 COLOR_CYCLE = [
         '#1f77b4',

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -35,11 +35,9 @@ def create_label_menu(points_layer, labels):
         the label menu qt widget
     """
     # Create the label selection menu
-    @magicgui(label={'choices': labels})
     def label_selection(label):
         return label
-
-    label_menu = label_selection.Gui()
+    label_menu = magicgui(label_selection, label={'choices': labels})
 
     def update_label_menu(event):
         """Update the label menu when the point selection changes"""


### PR DESCRIPTION
This PR updates the code to match the new magicgui API that was introduced in 0.2.0. In particular, we are now using the magicgui direct widget API. The requirements have been bumped to reflect the change.

Closes #2 .