### PR TITLE
Fixes for the last few napari releases

### DIFF
--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -73,54 +73,56 @@ def point_annotator(
         list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
     """
     stack = imread(im_path)
-    with napari.gui_qt():
-        viewer = napari.view_image(stack)
-        points_layer = viewer.add_points(
-            data=np.empty((0, 3)),
-            properties={'label': labels},
-            edge_color='label',
-            edge_color_cycle=COLOR_CYCLE,
-            symbol='o',
-            face_color='transparent',
-            edge_width=8,
-            size=12,
-        )
-        points_layer.edge_color_mode = 'cycle'
 
-        # add the label menu widget to the viewer
-        label_widget = create_label_menu(points_layer, labels)
-        viewer.window.add_dock_widget(label_widget)
+    viewer = napari.view_image(stack)
+    points_layer = viewer.add_points(
+        data=np.empty((0, 3)),
+        properties={'label': labels},
+        edge_color='label',
+        edge_color_cycle=COLOR_CYCLE,
+        symbol='o',
+        face_color='transparent',
+        edge_width=8,
+        size=12,
+    )
+    points_layer.edge_color_mode = 'cycle'
 
-        @viewer.bind_key('.')
-        def next_label(event=None):
-            """Keybinding to advance to the next label with wraparound"""
-            current_properties = points_layer.current_properties
-            current_label = current_properties['label'][0]
-            ind = list(labels).index(current_label)
-            new_ind = (ind + 1) % len(labels)
-            new_label = labels[new_ind]
-            current_properties['label'] = np.array([new_label])
-            points_layer.current_properties = current_properties
+    # add the label menu widget to the viewer
+    label_widget = create_label_menu(points_layer, labels)
+    viewer.window.add_dock_widget(label_widget)
 
-        def next_on_click(layer, event):
-            """Mouse click binding to advance the label when a point is added"""
-            if layer.mode == 'add':
-                next_label()
-                # by default, napari selects the point that was just added
-                # disable that behavior, as the highlight gets in the way
-                layer.selected_data = {}
+    @viewer.bind_key('.')
+    def next_label(event=None):
+        """Keybinding to advance to the next label with wraparound"""
+        current_properties = points_layer.current_properties
+        current_label = current_properties['label'][0]
+        ind = list(labels).index(current_label)
+        new_ind = (ind + 1) % len(labels)
+        new_label = labels[new_ind]
+        current_properties['label'] = np.array([new_label])
+        points_layer.current_properties = current_properties
 
-        points_layer.mode = 'add'
-        points_layer.mouse_drag_callbacks.append(next_on_click)
+    def next_on_click(layer, event):
+        """Mouse click binding to advance the label when a point is added"""
+        if layer.mode == 'add':
+            next_label()
+            # by default, napari selects the point that was just added
+            # disable that behavior, as the highlight gets in the way
+            layer.selected_data = {}
 
-        @viewer.bind_key(',')
-        def prev_label(event):
-            """Keybinding to decrement to the previous label with wraparound"""
-            current_properties = points_layer.current_properties
-            current_label = current_properties['label'][0]
-            ind = list(labels).index(current_label)
-            n_labels = len(labels)
-            new_ind = ((ind - 1) + n_labels) % n_labels
-            new_label = labels[new_ind]
-            current_properties['label'] = np.array([new_label])
-            points_layer.current_properties = current_properties
+    points_layer.mode = 'add'
+    points_layer.mouse_drag_callbacks.append(next_on_click)
+
+    @viewer.bind_key(',')
+    def prev_label(event):
+        """Keybinding to decrement to the previous label with wraparound"""
+        current_properties = points_layer.current_properties
+        current_label = current_properties['label'][0]
+        ind = list(labels).index(current_label)
+        n_labels = len(labels)
+        new_ind = ((ind - 1) + n_labels) % n_labels
+        new_label = labels[new_ind]
+        current_properties['label'] = np.array([new_label])
+        points_layer.current_properties = current_properties
+
+    napari.run()

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -104,10 +104,13 @@ def point_annotator(
     def next_on_click(layer, event):
         """Mouse click binding to advance the label when a point is added"""
         if layer.mode == 'add':
-            next_label()
             # by default, napari selects the point that was just added
             # disable that behavior, as the highlight gets in the way
+            # and also causes next_label to change the color of the
+            # point that was just added
             layer.selected_data = {}
+
+            next_label()
 
     points_layer.mode = 'add'
     points_layer.mouse_drag_callbacks.append(next_on_click)

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -1,38 +1,38 @@
 from typing import List
 
 from dask_image.imread import imread
+from magicgui.widgets import ComboBox, Container
 import napari
 import numpy as np
-from magicgui.widgets import ComboBox, Container
 
 COLOR_CYCLE = [
-        '#1f77b4',
-        '#ff7f0e',
-        '#2ca02c',
-        '#d62728',
-        '#9467bd',
-        '#8c564b',
-        '#e377c2',
-        '#7f7f7f',
-        '#bcbd22',
-        '#17becf'
+    '#1f77b4',
+    '#ff7f0e',
+    '#2ca02c',
+    '#d62728',
+    '#9467bd',
+    '#8c564b',
+    '#e377c2',
+    '#7f7f7f',
+    '#bcbd22',
+    '#17becf'
 ]
 
 
 def create_label_menu(points_layer, labels):
     """Create a label menu widget that can be added to the napari viewer dock
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     points_layer : napari.layers.Points
         a napari points layer
     labels : List[str]
         list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
 
-    Returns:
-    --------
-    label_menu : QComboBox
-        the label menu qt widget
+    Returns
+    -------
+    label_menu : Container
+        the magicgui Container with our dropdown menu widget
     """
     # Create the label selection menu
     label_menu = ComboBox(label='feature_label', choices=labels)
@@ -76,7 +76,6 @@ def point_annotator(
 
     viewer = napari.view_image(stack)
     points_layer = viewer.add_points(
-        data=[],
         ndim=3,
         property_choices={'label': labels},
         edge_color='label',

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -52,6 +52,7 @@ def create_label_menu(points_layer, labels):
         current_properties = points_layer.current_properties
         current_properties['label'] = np.asarray([selected_label])
         points_layer.current_properties = current_properties
+        points_layer.refresh_colors()
 
     label_menu.changed.connect(label_changed)
 
@@ -100,16 +101,16 @@ def point_annotator(
         new_label = labels[new_ind]
         current_properties['label'] = np.array([new_label])
         points_layer.current_properties = current_properties
+        points_layer.refresh_colors()
 
     def next_on_click(layer, event):
         """Mouse click binding to advance the label when a point is added"""
         if layer.mode == 'add':
-            # by default, napari selects the point that was just added
-            # disable that behavior, as the highlight gets in the way
+            # By default, napari selects the point that was just added.
+            # Disable that behavior, as the highlight gets in the way
             # and also causes next_label to change the color of the
-            # point that was just added
-            layer.selected_data = {}
-
+            # point that was just added.
+            layer.selected_data = set()
             next_label()
 
     points_layer.mode = 'add'
@@ -126,5 +127,6 @@ def point_annotator(
         new_label = labels[new_ind]
         current_properties['label'] = np.array([new_label])
         points_layer.current_properties = current_properties
+        points_layer.refresh_colors()
 
     napari.run()

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -47,9 +47,8 @@ def create_label_menu(points_layer, labels):
 
     points_layer.events.current_properties.connect(update_label_menu)
 
-    def label_changed(event):
+    def label_changed(selected_label):
         """Update the Points layer when the label menu selection changes"""
-        selected_label = event.value
         current_properties = points_layer.current_properties
         current_properties['label'] = np.asarray([selected_label])
         points_layer.current_properties = current_properties
@@ -77,12 +76,12 @@ def point_annotator(
     viewer = napari.view_image(stack)
     points_layer = viewer.add_points(
         data=np.empty((0, 3)),
-        properties={'label': labels},
+        property_choices={'label': labels},
         edge_color='label',
         edge_color_cycle=COLOR_CYCLE,
         symbol='o',
         face_color='transparent',
-        edge_width=8,
+        edge_width=0.5,  # fraction of point size
         size=12,
     )
     points_layer.edge_color_mode = 'cycle'

--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -76,7 +76,8 @@ def point_annotator(
 
     viewer = napari.view_image(stack)
     points_layer = viewer.add_points(
-        data=np.empty((0, 3)),
+        data=[],
+        ndim=3,
         property_choices={'label': labels},
         edge_color='label',
         edge_color_cycle=COLOR_CYCLE,


### PR DESCRIPTION
Based on the feedback in https://github.com/kevinyamauchi/PointAnnotator/issues/4 and https://github.com/napari/docs/pull/145 there are a few issues when using the points annotation example with recent versions of napari.

On the main branch here, there are problems at least dating back to v0.4.15.

There are a few fixes here that mostly make this example work as I think it should with the upcoming v0.4.19 and on napari's `main` branch.

- Use `napari.run` instead of the deprecated `gui_qt` context manager.
- Use `property_choices` instead of `properties` to specify possible label values.
- Explicitly set `ndim=3` with empty data.
- Manually call `Points.refresh_colors` to ensure displayed colors are up-to-date.
- Reset the selection before changing the current property (to avoid the side of effect of changing the last added point's label value and color).

After these changes, things aren't perfect (e.g. the selection is not empty after adding the point, changing the label with the keyboard shortcuts does not update the current color in the control panel) and I can't explain why. But these changes do make v0.4.15-v0.4.19 + main mostly work, so I still think these small changes are worth it.

Credit to @Omnistic and @constantinpape for noticing these issues and finding some of the fixes here.