### PR TITLE
Prepare for upcoming napari v0.5 release

### DIFF
--- a/pointannotator/gui.py
+++ b/pointannotator/gui.py
@@ -78,14 +78,14 @@ def point_annotator(
     points_layer = viewer.add_points(
         ndim=3,
         property_choices={'label': labels},
-        edge_color='label',
-        edge_color_cycle=COLOR_CYCLE,
+        border_color='label',
+        border_color_cycle=COLOR_CYCLE,
         symbol='o',
         face_color='transparent',
-        edge_width=0.5,  # fraction of point size
+        border_width=0.5,  # fraction of point size
         size=12,
     )
-    points_layer.edge_color_mode = 'cycle'
+    points_layer.border_color_mode = 'cycle'
 
     # add the label menu widget to the viewer
     label_widget = create_label_menu(points_layer, labels)


### PR DESCRIPTION
This makes two changes to prepare for the upcoming napari v0.5 release.

1\. Use `features` instead of `properties` (which will be deprecated in v0.5).

This is fairly straightforward with the biggest change needed using `pd.DataFrame` and `pd.Categorical` to define the label categories instead of using `property_choices`.

2\. Use `border_*` parameters instead of `edge_*` parameters for `add_points`.

The `edge_*` parameters will be deprecated for v0.5. On `main`, they are currently broken (https://github.com/napari/napari/issues/6978), but hopefully should be fixed for v0.5.0.

The motivation for writing this PR is to get the corresponding example in the napari docs up-to-date (e.g. https://github.com/napari/docs/pull/425).